### PR TITLE
Update elixir dependency to be >= 0.13.1.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ex2ms.Mixfile do
   def project do
     [ app: :ex2ms,
       version: "0.1.1-dev",
-      elixir: "~> 0.13.1",
+      elixir: "~> 0.13.1 or ~> 0.14.0 or ~> 0.14.0-dev",
       deps: deps ]
   end
 


### PR DESCRIPTION
Not sure if that version spec is necessary to match both released and upcoming 0.14 versions.

Also, what's necessary to bring this to hex.pm?
