### PR TITLE
Eliminate warning when using with Elixir v0.15.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ex2ms.Mixfile do
   def project do
     [ app: :ex2ms,
       version: "1.1.0",
-      elixir: "~> 0.13.1 or ~> 0.14.0 or ~> 0.14.0-dev",
+      elixir: "~> 0.13.1 or ~> 0.14.0 or ~> 0.14.0-dev or ~> 0.15.0",
       description: description,
       package: package,
       deps: [] ]


### PR DESCRIPTION
Currently shows:

```
~/src/ex_rated (master ✗)$ iex -S mix
Erlang/OTP 17 [erts-6.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

==> ex2ms
warning: the dependency ex2ms requires Elixir "~> 0.13.1 or ~> 0.14.0 or ~> 0.14.0-dev" but you are running on v0.15.1
```
