### PR TITLE
Eliminate warning: variable state is unused

### DIFF
--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -78,7 +78,7 @@ defmodule Ex2ms do
     {Enum.map(list, &translate_cond(&1, state)) |> List.to_tuple}
   end
 
-  defp translate_cond({:^, _, [var]}, state) do
+  defp translate_cond({:^, _, [var]}, _state) do
     {:unquote, [], [var]}
   end
 


### PR DESCRIPTION
Previously:

```
/tmp/ex2ms (master ✗)$ mix test
lib/ex2ms.ex:81: warning: variable state is unused
```

Now the test suite still passes and compilation doesn't complain about this unused var.
