### PR TITLE
Mixfile update to handle Elixir 1.3.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ex2ms.Mixfile do
   def project do
     [ app: :ex2ms,
       version: "1.4.0",
-      elixir: "<= 1.3.0",
+      elixir: "~> 1.0",
       description: description,
       package: package,
       deps: [] ]


### PR DESCRIPTION
I pulled this locally and ran the tests. They all passed using Elixir 1.3.1.

The [changelog](https://github.com/elixir-lang/elixir/blob/v1.3.1/CHANGELOG.md) for the 1.3.0 to 1.3.1 isn't all that scary compared to the 1.2 -> 1.3.0.

I am not terribly sure how best to handle versioning in the mix.exs when it comes to Elixir versions. Any suggestions are welcome.