### PR TITLE
Fix elixir 1.4.0 compiler warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule Ex2ms.Mixfile do
     [ app: :ex2ms,
       version: "1.4.0",
       elixir: "~> 1.0",
-      description: description,
-      package: package,
+      description: description(),
+      package: package(),
       deps: [] ]
   end
 


### PR DESCRIPTION
This PR resolves warnings when compiling with elixir 1.4.0
```
warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /Users/nitrino/develop/xxx/xxx/code/deps/ex2ms/mix.exs:8

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /Users/nitrino/develop/xxx/xxx/code/deps/ex2ms/mix.exs:9
```