### PR TITLE
Add support for custom guard macros

### DIFF
--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -15,7 +15,7 @@ defmodule Ex2ms do
     :===, :==, :!==, :!=, :self]
 
   @elixir_erlang [
-    ===: :"=:=", !==: :"=/=", !=: :"/=", <=: :"=<", and: :andalso,or: :orelse]
+    ===: :"=:=", !==: :"=/=", !=: :"/=", <=: :"=<", and: :andalso, or: :orelse]
 
   Enum.map(@guard_functions, fn(atom) ->
     defp is_guard_function(unquote(atom)), do: true

--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -92,8 +92,8 @@ defmodule Ex2ms do
         match_args = Enum.map(args, &translate_cond(&1, state))
         match_fun = map_elixir_erlang(fun)
         [match_fun|match_args] |> List.to_tuple
-      is_expandable(fun_call, state.caller) ->
-        translate_cond Macro.expand_once(fun_call, state.caller), state
+      expansion = is_expandable(fun_call, state.caller) ->
+        translate_cond expansion, state
       true ->
         raise_expression_error()
     end
@@ -189,7 +189,8 @@ defmodule Ex2ms do
   defp do_translate_param(_, _state), do: raise_parameter_error()
 
   defp is_expandable(ast, env) do
-    ast !== Macro.expand_once(ast, env)
+    expansion = Macro.expand_once ast, env
+    if ast !== expansion, do: expansion, else: false
   end
 
   defp raise_expression_error do

--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -28,8 +28,7 @@ defmodule Ex2ms do
   defp map_elixir_erlang(atom), do: atom
 
   defmacro fun([do: clauses]) do
-    outer_vars = __CALLER__.vars
-    Enum.map(clauses, fn({:->, _, clause}) -> translate_clause(clause, outer_vars) end) |> Macro.escape(unquote: true)
+    Enum.map(clauses, fn({:->, _, clause}) -> translate_clause(clause, __CALLER__) end) |> Macro.escape(unquote: true)
   end
 
   @doc """
@@ -52,8 +51,8 @@ defmodule Ex2ms do
     end
   end
 
-  defp translate_clause([head, body], outer_vars) do
-    {head, conds, state} = translate_head(head, outer_vars)
+  defp translate_clause([head, body], caller) do
+    {head, conds, state} = translate_head(head, caller)
     case head do
       %{} -> raise_parameter_error()
       _ ->
@@ -87,13 +86,16 @@ defmodule Ex2ms do
     {:unquote, [], [var]}
   end
 
-  defp translate_cond({fun, _, args}, state) when is_atom(fun) and is_list(args) do
-    if is_guard_function(fun) do
-      match_args = Enum.map(args, &translate_cond(&1, state))
-      match_fun = map_elixir_erlang(fun)
-      [match_fun|match_args] |> List.to_tuple
-    else
-      raise_expression_error()
+  defp translate_cond(fun_call = {fun, _, args}, state) when is_atom(fun) and is_list(args) do
+    cond do
+      is_guard_function(fun) ->
+        match_args = Enum.map(args, &translate_cond(&1, state))
+        match_fun = map_elixir_erlang(fun)
+        [match_fun|match_args] |> List.to_tuple
+      is_expandable(fun_call, state.caller) ->
+        translate_cond Macro.expand_once(fun_call, state.caller), state
+      true ->
+        raise_expression_error()
     end
   end
 
@@ -107,33 +109,33 @@ defmodule Ex2ms do
 
   defp translate_cond(_, _state), do: raise_expression_error()
 
-  defp translate_head([{:when, _, [param, cond]}], outer_vars) do
-    {head, state} = translate_param(param, outer_vars)
+  defp translate_head([{:when, _, [param, cond]}], caller) do
+    {head, state} = translate_param(param, caller)
     cond = translate_cond(cond, state)
     {head, [cond], state}
   end
 
-  defp translate_head([param], outer_vars) do
-    {head, state} = translate_param(param, outer_vars)
+  defp translate_head([param], caller) do
+    {head, state} = translate_param(param, caller)
     {head, [], state}
   end
 
   defp translate_head(_, _), do: raise_parameter_error()
 
-  defp translate_param(param, outer_vars) do
+  defp translate_param(param, caller) do
     {param, state} = case param do
       {:=, _, [{var, _, nil}, param]} when is_atom(var) ->
-        {param, %{vars: [{var, "$_"}], count: 0, outer_vars: outer_vars}}
+        {param, %{vars: [{var, "$_"}], count: 0, outer_vars: caller.vars, caller: caller}}
       {:=, _, [param, {var, _, nil}]} when is_atom(var) ->
-        {param, %{vars: [{var, "$_"}], count: 0, outer_vars: outer_vars}}
+        {param, %{vars: [{var, "$_"}], count: 0, outer_vars: caller.vars, caller: caller}}
       {var, _, nil} when is_atom(var) ->
-        {param, %{vars: [], count: 0, outer_vars: outer_vars}}
+        {param, %{vars: [], count: 0, outer_vars: caller.vars, caller: caller}}
       {:{}, _, list} when is_list(list) ->
-        {param, %{vars: [], count: 0, outer_vars: outer_vars}}
+        {param, %{vars: [], count: 0, outer_vars: caller.vars, caller: caller}}
       {:%{}, _, list} when is_list(list) ->
-        {param, %{vars: [], count: 0, outer_vars: outer_vars}}
+        {param, %{vars: [], count: 0, outer_vars: caller.vars, caller: caller}}
       {_, _} ->
-        {param, %{vars: [], count: 0, outer_vars: outer_vars}}
+        {param, %{vars: [], count: 0, outer_vars: caller.vars, caller: caller}}
       _ -> raise_parameter_error()
     end
     do_translate_param(param, state)
@@ -185,6 +187,10 @@ defmodule Ex2ms do
   end
 
   defp do_translate_param(_, _state), do: raise_parameter_error()
+
+  defp is_expandable(ast, env) do
+    ast !== Macro.expand_once(ast, env)
+  end
 
   defp raise_expression_error do
     raise ArgumentError, message: "illegal expression in matchspec"

--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -11,8 +11,8 @@ defmodule Ex2ms do
 
   @guard_functions @bool_functions ++ [
     :abs, :element, :hd, :count, :node, :round, :size, :tl, :trunc, :+, :-, :*,
-    :div, :rem, :band, :bor, :bxor, :bnot, :bsl, :bsr, :>, :>=, :<, :<=, :===,
-    :==, :!==, :!=, :self]
+    :/, :div, :rem, :band, :bor, :bxor, :bnot, :bsl, :bsr, :>, :>=, :<, :<=,
+    :===, :==, :!==, :!=, :self]
 
   @elixir_erlang [
     ===: :"=:=", !==: :"=/=", !=: :"/=", <=: :"=<", and: :andalso,or: :orelse]

--- a/test/ex2ms_test.exs
+++ b/test/ex2ms_test.exs
@@ -63,6 +63,18 @@ defmodule Ex2msTest do
     assert ms == [{:"$1", [], [:"$1", 0] }]
   end
 
+  test "custom guard macro" do
+    ms = fun do x when custom_guard x -> x end
+    assert ms == [{:"$1", [{:andalso, {:>, :"$1", 3}, {:"/=", :"$1", 5}}], [:"$1"]}]
+  end
+
+  test "nested custom guard macro" do
+    ms = fun do x when nested_custom_guard x -> x end
+    assert ms == [{:"$1",
+      [{:andalso, {:andalso, {:>, :"$1", 3}, {:"/=", :"$1", 5}},
+        {:andalso, {:>, {:+, :"$1", 1}, 3}, {:"/=", {:+, :"$1", 1}, 5}}}], [:"$1"]}]
+  end
+
   test "map is illegal alone in body" do
     assert_raise ArgumentError, "illegal expression in matchspec", fn ->
       delay_compile(fun do {x, z} -> %{x: z} end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,4 +7,16 @@ defmodule TestHelpers do
       Code.eval_quoted(unquote(quoted), [], __ENV__)
     end
   end
+
+  defmacro custom_guard(x) do
+    quote do
+      unquote(x) > 3 and unquote(x) != 5
+    end
+  end
+
+  defmacro nested_custom_guard(x) do
+    quote do
+      custom_guard(unquote(x)) and custom_guard(unquote(x) + 1)
+    end
+  end
 end


### PR DESCRIPTION
I have added support for custom guard macros. If a given function call is not a guard function, it will then determine if the call is expandable; and, if so, pass the expansion on to another call to `translate_cond`.

Also, `:/` was missing from the list of guard functions, causing `fun/1` to raise whenever it is used. I have added it in this PR as well.