### PR TITLE
Fix source_url in project

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,13 +2,14 @@ defmodule Ex2ms.Mixfile do
   use Mix.Project
 
   @version "1.5.0"
+  @github_url "https://github.com/ericmj/ex2ms"
 
   def project do
     [
       app: :ex2ms,
       version: @version,
       elixir: "~> 1.0",
-      source_url: "https://github.com/ericmj",
+      source_url: @github_url,
       docs: [source_ref: "v#{@version}", main: "readme", extras: ["README.md"]],
       description: description(),
       package: package(),
@@ -35,7 +36,7 @@ defmodule Ex2ms.Mixfile do
       files: ["lib", "mix.exs", "README.md"],
       maintainers: ["Eric Meadows-Jönsson", "Martin Schurrer"],
       licenses: ["Apache 2.0"],
-      links: %{"GitHub" => "https://github.com/ericmj/ex2ms"}
+      links: %{"GitHub" => @github_url}
     ]
   end
 end


### PR DESCRIPTION
The project source_url attribute is missing the `/ex2ms` path segment, causing bad links to be generated in the hexdocs.