### PR TITLE
Problem: no support for `in` guard

### DIFF
--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -151,6 +151,22 @@ defmodule Ex2ms do
     {:const, {:unquote, [], [var]}}
   end
 
+  defp translate_cond({:in, _, [{arg, _, _}, args]}, state) when is_list(args) do
+    arg =
+      if match_var = state.vars[arg] do
+        :"#{match_var}"
+      else
+        arg
+      end
+
+    match_args =
+      Enum.map(args, fn element ->
+        {:==, arg, element}
+      end)
+
+    [:or | match_args] |> List.to_tuple()
+  end
+
   defp translate_cond(fun_call = {fun, _, args}, state) when is_atom(fun) and is_list(args) do
     cond do
       is_guard_function(fun) ->

--- a/test/ex2ms_test.exs
+++ b/test/ex2ms_test.exs
@@ -65,6 +65,16 @@ defmodule Ex2msTest do
             end) == [{:"$1", [{:andalso, true, false}], [0]}]
   end
 
+  test "`in` guard" do
+    ms =
+      fun do
+        x when x in ["a", "b"] -> x
+      end
+
+    assert ms == [{:"$1", [{:or, {:==, :"$1", "a"}, {:==, :"$1", "b"}}], [:"$1"]}]
+    assert :ets.test_ms("a", ms) == {:ok, "a"}
+  end
+
   test "multiple funs" do
     ms =
       fun do


### PR DESCRIPTION
Solution: add a naive implementation of it

---

This is definitely not a "generalized" solution for other similar cases (if they are ever to appear), but I needed something quick that (I think can work). Apologies if I didn't understand how to use the internals correctly. Happy to get any feedback.