### PR TITLE
Support outer variables in conds and bodies

### DIFF
--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -137,7 +137,10 @@ defmodule Ex2ms do
     if match_var = state.vars[var] do
       :"#{match_var}"
     else
-      raise ArgumentError, message: "variable `#{var}` is unbound in matchspec"
+      case Keyword.fetch(state.outer_vars, var) do
+        {:ok, context} -> {:unquote, [], [{var, [], context}]}
+        _ -> raise ArgumentError, message: "variable `#{var}` is unbound"
+      end
     end
   end
 

--- a/test/ex2ms_test.exs
+++ b/test/ex2ms_test.exs
@@ -185,8 +185,15 @@ defmodule Ex2msTest do
                  end
   end
 
+  test "outer bound variable" do
+    y = 123
+    assert (fun do
+              x -> y
+            end) == [{:"$1", [], [123]}]
+  end
+
   test "unbound variable" do
-    assert_raise ArgumentError, "variable `y` is unbound in matchspec", fn ->
+    assert_raise ArgumentError, "variable `y` is unbound", fn ->
       delay_compile(
         fun do
           x -> y


### PR DESCRIPTION
This allows one to use external variables in match specification bodies and conds, for example: `y = 123; fun do {x} -> x + y end`.