### PR TITLE
Keep variable contexts

### DIFF
--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -137,7 +137,9 @@ defmodule Ex2ms do
     if match_var = state.vars[var] do
       :"#{match_var}"
     else
-      raise ArgumentError, message: "variable `#{var}` is unbound in matchspec"
+      raise ArgumentError,
+        message:
+          "variable `#{var}` is unbound in matchspec (use `^` for outer variables and expressions)"
     end
   end
 
@@ -259,8 +261,8 @@ defmodule Ex2ms do
     {List.to_tuple(list), state}
   end
 
-  defp do_translate_param({:^, _, [var]}, state) do
-    {{:unquote, [], [var]}, state}
+  defp do_translate_param({:^, _, [expr]}, state) do
+    {{:unquote, [], [expr]}, state}
   end
 
   defp do_translate_param(list, state) when is_list(list) do

--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -133,13 +133,13 @@ defmodule Ex2ms do
     [translate_cond(expr, state)]
   end
 
-  defp translate_cond({var, _, nil}, state) when is_atom(var) do
-    if match_var = state.vars[var] do
+  defp translate_cond({name, _, context}, state) when is_atom(name) and is_atom(context) do
+    if match_var = state.vars[{name, context}] do
       :"#{match_var}"
     else
       raise ArgumentError,
         message:
-          "variable `#{var}` is unbound in matchspec (use `^` for outer variables and expressions)"
+          "variable `#{name}` is unbound in matchspec (use `^` for outer variables and expressions)"
     end
   end
 
@@ -200,31 +200,25 @@ defmodule Ex2ms do
 
     {param, state} =
       case param do
-        {:=, _, [{var, _, nil}, param]} when is_atom(var) ->
-          vars = Macro.Env.vars(caller)
-          state = %{vars: [{var, "$_"}], count: 0, outer_vars: vars, caller: caller}
+        {:=, _, [{name, _, context}, param]} when is_atom(name) and is_atom(context) ->
+          state = %{vars: %{{name, context} => "$_"}, count: 0, caller: caller}
           {Macro.expand(param, %{caller | context: :match}), state}
 
-        {:=, _, [param, {var, _, nil}]} when is_atom(var) ->
-          vars = Macro.Env.vars(caller)
-          state = %{vars: [{var, "$_"}], count: 0, outer_vars: vars, caller: caller}
+        {:=, _, [param, {name, _, context}]} when is_atom(name) and is_atom(context) ->
+          state = %{vars: %{{name, context} => "$_"}, count: 0, caller: caller}
           {Macro.expand(param, %{caller | context: :match}), state}
 
-        {var, _, nil} when is_atom(var) ->
-          vars = Macro.Env.vars(caller)
-          {param, %{vars: [], count: 0, outer_vars: vars, caller: caller}}
+        {name, _, context} when is_atom(name) and is_atom(context) ->
+          {param, %{vars: %{}, count: 0, caller: caller}}
 
         {:{}, _, list} when is_list(list) ->
-          vars = Macro.Env.vars(caller)
-          {param, %{vars: [], count: 0, outer_vars: vars, caller: caller}}
+          {param, %{vars: %{}, count: 0, caller: caller}}
 
         {:%{}, _, list} when is_list(list) ->
-          vars = Macro.Env.vars(caller)
-          {param, %{vars: [], count: 0, outer_vars: vars, caller: caller}}
+          {param, %{vars: %{}, count: 0, caller: caller}}
 
         {_, _} ->
-          vars = Macro.Env.vars(caller)
-          {param, %{vars: [], count: 0, outer_vars: vars, caller: caller}}
+          {param, %{vars: %{}, count: 0, caller: caller}}
 
         _ ->
           raise_parameter_error(param)
@@ -233,20 +227,21 @@ defmodule Ex2ms do
     do_translate_param(param, state)
   end
 
-  defp do_translate_param({:_, _, nil}, state) do
+  defp do_translate_param({:_, _, context}, state) when is_atom(context) do
     {:_, state}
   end
 
-  defp do_translate_param({var, _, nil}, state) when is_atom(var) do
-    if match_var = state.vars[var] do
+  defp do_translate_param({name, _, context}, state) when is_atom(name) and is_atom(context) do
+    if match_var = state.vars[{name, context}] do
       {:"#{match_var}", state}
     else
       match_var = "$#{state.count + 1}"
 
-      state =
+      state = %{
         state
-        |> Map.update!(:vars, &[{var, match_var} | &1])
-        |> Map.update!(:count, &(&1 + 1))
+        | vars: Map.put(state.vars, {name, context}, match_var),
+          count: state.count + 1
+      }
 
       {:"#{match_var}", state}
     end

--- a/test/ex2ms_test.exs
+++ b/test/ex2ms_test.exs
@@ -281,6 +281,15 @@ defmodule Ex2msTest do
     assert {:ok, {bound, {:some, :record}}} === :ets.test_ms({:some, :record}, ms)
   end
 
+  test "outer expressions get evaluated" do
+    ms =
+      fun do
+        arg -> {^{1, 1 + 1, 3}, arg}
+      end
+
+    assert ms == [{:"$1", [], [{{{:const, {1, 2, 3}}, :"$1"}}]}]
+  end
+
   defmacro test_contexts(var) do
     quote do
       var = {1, 2, 3}

--- a/test/ex2ms_test.exs
+++ b/test/ex2ms_test.exs
@@ -281,5 +281,22 @@ defmodule Ex2msTest do
     assert {:ok, {bound, {:some, :record}}} === :ets.test_ms({:some, :record}, ms)
   end
 
+  defmacro test_contexts(var) do
+    quote do
+      var = {1, 2, 3}
+
+      fun do
+        {^var, _} -> ^unquote(var)
+      end
+    end
+  end
+
+  test "contexts are preserved" do
+    var = 42
+    ms = test_contexts(var)
+
+    assert {:ok, 42} === :ets.test_ms({{1, 2, 3}, 123}, ms)
+  end
+
   doctest Ex2ms
 end

--- a/test/ex2ms_test.exs
+++ b/test/ex2ms_test.exs
@@ -186,13 +186,15 @@ defmodule Ex2msTest do
   end
 
   test "unbound variable" do
-    assert_raise ArgumentError, "variable `y` is unbound in matchspec", fn ->
-      delay_compile(
-        fun do
-          x -> y
-        end
-      )
-    end
+    assert_raise ArgumentError,
+                 "variable `y` is unbound in matchspec (use `^` for outer variables and expressions)",
+                 fn ->
+                   delay_compile(
+                     fun do
+                       x -> y
+                     end
+                   )
+                 end
   end
 
   test "invalid expression" do


### PR DESCRIPTION
This allows to use `fun/1` in macros. While at it, use a map instead of keyword list for variables.

This one is on top of https://github.com/ericmj/ex2ms/pull/30 because it touches the same code. If needed I can rebase onto master.