### PR TITLE
Add support for new actions caller_line and current_stacktrace

### DIFF
--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -70,6 +70,8 @@ defmodule Ex2ms do
     :trace,
     :display,
     :caller,
+    :caller_line,
+    :current_stacktrace,
     :set_tcw,
     :silent
   ]


### PR DESCRIPTION
Added in OTP 26.
Ref OTP-18494

"Support has been added in ms_transform for the actions caller_line/0, current_stacktrace/0, and current_stacktrace/1."

From https://www.erlang.org/patches/otp-26.0