### PR TITLE
Allow max and min guard functions

### DIFF
--- a/lib/ex2ms.ex
+++ b/lib/ex2ms.ex
@@ -50,6 +50,8 @@ defmodule Ex2ms do
     :element,
     :hd,
     :map_get,
+    :max,
+    :min,
     :node,
     :rem,
     :round,


### PR DESCRIPTION
`max` and `min` are supported in guards since OTP 26: https://www.erlang.org/doc/system/expressions.html#guard-expressions